### PR TITLE
Unify empty file/directory test and fix it

### DIFF
--- a/tests/database-tests.at
+++ b/tests/database-tests.at
@@ -44,14 +44,9 @@ AT_KEYWORDS([text content])
 AT_CHECK_UNQUOTED([grep -nrP '\r' $ROOT_DIR], [1], [], [])
 AT_CLEANUP
 
-AT_SETUP([for no empty files])
+AT_SETUP([for no empty files or directories])
 AT_KEYWORDS([text content])
-AT_CHECK_UNQUOTED([find $ROOT_DIR -type f -empty], [1], [], [])
-AT_CLEANUP
-
-AT_SETUP([for no empty directories])
-AT_KEYWORDS([text content])
-AT_CHECK_UNQUOTED([find $ROOT_DIR -type d -empty], [1], [], [])
+AT_CHECK_UNQUOTED([IFS=$''; result=$(find $ROOT_DIR -empty); if [[[ ${result} != "" ]]]; then echo ${result} && exit 1; fi], [0], [], [])
 AT_CLEANUP
 
 AT_SETUP([for no copyright sign within texts])

--- a/tests/database-tests.at
+++ b/tests/database-tests.at
@@ -44,9 +44,14 @@ AT_KEYWORDS([text content])
 AT_CHECK_UNQUOTED([grep -nrP '\r' $ROOT_DIR], [1], [], [])
 AT_CLEANUP
 
-AT_SETUP([for no empty files or directories])
+AT_SETUP([for no empty files])
 AT_KEYWORDS([text content])
-AT_CHECK_UNQUOTED([IFS=$''; result=$(find $ROOT_DIR -empty); if [[[ ${result} != "" ]]]; then echo ${result} && exit 1; fi], [0], [], [])
+AT_CHECK_UNQUOTED([find $ROOT_DIR -type f -empty], [0], [], [])
+AT_CLEANUP
+
+AT_SETUP([for no empty directories])
+AT_KEYWORDS([text content])
+AT_CHECK_UNQUOTED([find $ROOT_DIR -type d -empty], [0], [], [])
 AT_CLEANUP
 
 AT_SETUP([for no copyright sign within texts])


### PR DESCRIPTION
The tests operated on assumption that find returns an error code when no file is found, that is false - https://serverfault.com/a/225800

I accounted for that and also unified the file/directory test, as find can simply match both in the same query, so no need to make it double.