### PR TITLE
Change 'Written by' to 'Original text by'

### DIFF
--- a/database/3/3 Doors Down/The Better Life/Kryptonite
+++ b/database/3/3 Doors Down/The Better Life/Kryptonite
@@ -46,5 +46,5 @@ __________
 Name  Kryptonite
 Album  The Better Life
 Artist  3 Doors Down
-Written by  Bradley Kirk Arnold,  Matthew Darrick Roberts,  Robert Todd Harrell
+Original text by  Bradley Kirk Arnold,  Matthew Darrick Roberts,  Robert Todd Harrell
 Copyright  Universal Music Publishing Group

--- a/database/A/A Flock of Seagulls/A Flock of Seagulls/I Ran (So Far Away)
+++ b/database/A/A Flock of Seagulls/A Flock of Seagulls/I Ran (So Far Away)
@@ -49,7 +49,7 @@ _________________________
 Name  I Ran (So Far Away)
 Artist  A Flock of Seagulls
 Album  A Flock of Seagulls
-Written by  Alistair M. Score,
+Original text by  Alistair M. Score,
   Francis Reynolds Maudsley,
   Michael Score, Paul Reynolds
 Copyright  Universal Music Publishing Group

--- a/database/A/A Perfect Circle/Emotive/Passive
+++ b/database/A/A Perfect Circle/Emotive/Passive
@@ -73,7 +73,7 @@ _____________
 Name  Passive
 Artist  A Perfect Circle
 Album  eMOTIVe
-Written by  Billy Howerdel,  Danny Lohner,
+Original text by  Billy Howerdel,  Danny Lohner,
   Trent Reznor,  Maynard James Keenan
 Copyright  EMI Music Publishing,
   Sony/ATV Music Publishing LLC

--- a/database/A/A Perfect Circle/Mer de Noms/Magdalena
+++ b/database/A/A Perfect Circle/Mer de Noms/Magdalena
@@ -32,5 +32,5 @@ _______________
 Name  Magdalena
 Artist  A Perfect Circle
 Album  Mer de Noms
-Written by  Billy Howerdel,  Maynard James Keenan
+Original text by  Billy Howerdel,  Maynard James Keenan
 Copyright  EMI Music Publishing

--- a/database/A/A Perfect Circle/Thirteenth Step/Weak and Powerless
+++ b/database/A/A Perfect Circle/Thirteenth Step/Weak and Powerless
@@ -36,5 +36,5 @@ ________________________
 Name  Weak and Powerless
 Artist  A Perfect Circle
 Album  Thirteenth Step
-Written by  Billy Howerdel,  Maynard Keenan
+Original text by  Billy Howerdel,  Maynard Keenan
 Copyright  Sony/ATV Music Publishing LLC

--- a/database/A/A Split-Second/Ballistic Statues/Rigor Mortis
+++ b/database/A/A Split-Second/Ballistic Statues/Rigor Mortis
@@ -18,4 +18,4 @@ __________________
 Name  Rigor Mortis
 Artist  A Split-Second
 Album  Ballistic Statues
-Written by  Marc Heyndrickx
+Original text by  Marc Heyndrickx

--- a/database/A/Alannah Myles/Black Velvet/Black Velvet
+++ b/database/A/Alannah Myles/Black Velvet/Black Velvet
@@ -41,5 +41,5 @@ If you please, if you please, if you please...
 __________________
 Name  Black Velvet
 Artist  Alannah Myles
-Written by  Christopher Ward,  David Tyson
+Original text by  Christopher Ward,  David Tyson
 Copyright  Atlantic Records (WMG)

--- a/database/A/Alice In Chains/Sap/Am I Inside
+++ b/database/A/Alice In Chains/Sap/Am I Inside
@@ -37,4 +37,4 @@ _________________
 Name  Am I Inside
 Album  Sap
 Artist  Alice In Chains
-Written by  Layne Staley
+Original text by  Layne Staley

--- a/database/A/Angelfish/Angelfish/The Sun Won't Shine
+++ b/database/A/Angelfish/Angelfish/The Sun Won't Shine
@@ -47,6 +47,6 @@ _________________________
 Name  The Sun Won't Shine
 Artist  Angelfish
 Album  Angelfish
-Written by  Derek Kelly,  Martin Edward Metcalfe
+Original text by  Derek Kelly,  Martin Edward Metcalfe
 Copyright  Universal Music Publishing Group
 MusicBrainz ID  7bcaec2a-a54c-49a8-83be-829a7fe13793

--- a/database/A/Anthony Rother/Hacker/Hacker
+++ b/database/A/Anthony Rother/Hacker/Hacker
@@ -50,5 +50,5 @@ ________________________________
 Name  Hacker
 Artist  Anthony Rother
 Album  Hacker
-Written by  Anthony Ramon Rother
+Original text by  Anthony Ramon Rother
 Copyright  Hanseatic Musikverlag Gmbh & Co. Kg

--- a/database/B/Bad Religion/The New America/I Love My Computer
+++ b/database/B/Bad Religion/The New America/I Love My Computer
@@ -80,5 +80,5 @@ Name  I Love My Computer
 Artist  Bad Religion
 Album  The New America
 MusicBrainz ID  c49ea399-2758-4bbf-81e6-ee79d0ea4cff
-Written by  Greg Graffin
+Original text by  Greg Graffin
 Copyright  Warner/Chappell Music, Inc

--- a/database/B/Billy Idol/Cyberpunk/Adam in Chains
+++ b/database/B/Billy Idol/Cyberpunk/Adam in Chains
@@ -90,5 +90,5 @@ ____________________
 Name  Adam in Chains
 Artist  Billy Idol
 Album  Cyberpunk
-Written by  Billy Idol,  Robin Jonathon Coventry Hancock
+Original text by  Billy Idol,  Robin Jonathon Coventry Hancock
 Copyright  BMG Rights Management US, LLC,  Downtown Music Publishing LLC

--- a/database/B/Billy Idol/Cyberpunk/Heroin
+++ b/database/B/Billy Idol/Cyberpunk/Heroin
@@ -76,4 +76,4 @@ ____________
 Name  Heroin
 Artist  Billy Idol
 Album  Cyberpunk
-Written by  Lou Reed
+Original text by  Lou Reed

--- a/database/B/Billy Idol/Cyberpunk/Love Labours On
+++ b/database/B/Billy Idol/Cyberpunk/Love Labours On
@@ -65,6 +65,6 @@ _____________________
 Name  Love Labours On
 Artist  Billy Idol
 Album  Cyberpunk
-Written by  Billy Idol,  Mark Younger-Smith
+Original text by  Billy Idol,  Mark Younger-Smith
 Copyright  Sony/ATV Music Publishing LLC,
   Warner/Chappell Music, Inc

--- a/database/B/Billy Idol/Rebel Yell/Flesh for Fantasy
+++ b/database/B/Billy Idol/Rebel Yell/Flesh for Fantasy
@@ -94,6 +94,6 @@ _______________________
 Name  Flesh for Fantasy
 Artist  Billy Idol
 Album  Rebel Yell
-Written by  Billy Idol,  Steve Stevens,  William Broad
+Original text by  Billy Idol,  Steve Stevens,  William Broad
 Copyright  Warner/Chappell Music, Inc,
   BMG Rights Management US, LLC

--- a/database/B/Billy Idol/Whiplash Smile/Sweet Sixteen
+++ b/database/B/Billy Idol/Whiplash Smile/Sweet Sixteen
@@ -109,5 +109,5 @@ ___________________
 Name  Sweet Sixteen
 Artist  Billy Idol
 Album  Whiplash Smile
-Written by  Billy Idol
+Original text by  Billy Idol
 Copyright  BMG Rights Management US, LLC

--- a/database/B/Brian Setzer/Nitro Burnin' Funny Daddy/Don't Trust a Woman (In a Black Cadillac)
+++ b/database/B/Brian Setzer/Nitro Burnin' Funny Daddy/Don't Trust a Woman (In a Black Cadillac)
@@ -87,4 +87,4 @@ ________________________
 Name  Don't Don't Trust a Woman (In a Black Cadillac)
 Artist  Brian Setzer
 Album  Nitro Burnin' Funny Daddy
-Written by  Brian Setzer
+Original text by  Brian Setzer

--- a/database/C/Clutch/Earth Rocker/Gone Cold
+++ b/database/C/Clutch/Earth Rocker/Gone Cold
@@ -53,5 +53,5 @@ __________________
 Name  Gone Cold
 Artist  Clutch
 Album  Earth Rocker
-Written by  Fallon Neil,  Gaster Jean Paul,  Maines Dan,  Sult Richard Timothy
+Original text by  Fallon Neil,  Gaster Jean Paul,  Maines Dan,  Sult Richard Timothy
 Copyright  Sea Gator Music

--- a/database/C/Concrete Blonde/Bloodletting/Caroline
+++ b/database/C/Concrete Blonde/Bloodletting/Caroline
@@ -57,5 +57,5 @@ ______________
 Name  Caroline
 Artist  Concrete Blonde
 Album  Bloodletting
-Written by  Johnette Lin Napolitano
+Original text by  Johnette Lin Napolitano
 Copyright  Sony/ATV Music Publishing LLC,  Warner/Chappell Music, Inc

--- a/database/C/Concrete Blonde/Mexican Moon/Heal It Up
+++ b/database/C/Concrete Blonde/Mexican Moon/Heal It Up
@@ -50,6 +50,6 @@ ________________
 Name  Heal It Up
 Artist  Concrete Blonde
 Album  Mexican Moon
-Written by  Johnette Lin Napolitano
+Original text by  Johnette Lin Napolitano
 Copyright  Sony/ATV Music Publishing LLC,  Warner/Chappell Music, Inc,
   The Bicycle Music Company

--- a/database/C/Crying Vessel/Killing Time/Killing Time
+++ b/database/C/Crying Vessel/Killing Time/Killing Time
@@ -39,4 +39,4 @@ ________________________
 Name  Killing Time
 Artist  Crying Vessel
 Album  Killing Time (EP)
-Written by  Slade Templeton
+Original text by  Slade Templeton

--- a/database/C/Curve/Come Clean/Killer Baby
+++ b/database/C/Curve/Come Clean/Killer Baby
@@ -51,4 +51,4 @@ _________________
 Name  Killer Baby
 Artist  Curve
 Album  Come Clean
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Come Clean/Recovery
+++ b/database/C/Curve/Come Clean/Recovery
@@ -70,4 +70,4 @@ ______________
 Name  Recovery
 Artist  Curve
 Album  Come Clean
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Cuckoo/Men Are From Mars, Women Are From Venus
+++ b/database/C/Curve/Cuckoo/Men Are From Mars, Women Are From Venus
@@ -62,4 +62,4 @@ _____________________________________________
 Name  Men Are From Mars, Women Are From Venus
 Artist  Curve
 Album  Cuckoo
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Cuckoo/Missing Link
+++ b/database/C/Curve/Cuckoo/Missing Link
@@ -78,4 +78,4 @@ __________________
 Name  Missing Link
 Artist  Curve
 Album  Cuckoo
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Cuckoo/Turkey Crossing
+++ b/database/C/Curve/Cuckoo/Turkey Crossing
@@ -85,4 +85,4 @@ _____________________
 Name  Turkey Crossing
 Artist  Curve
 Album  Cuckoo
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Cuckoo/Unreadable Communication
+++ b/database/C/Curve/Cuckoo/Unreadable Communication
@@ -57,4 +57,4 @@ ______________________________
 Name  Unreadable Communication
 Artist  Curve
 Album  Cuckoo
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Doppelgänger/Already Yours
+++ b/database/C/Curve/Doppelgänger/Already Yours
@@ -42,4 +42,4 @@ ___________________
 Name  Already Yours
 Artist  Curve
 Album  Doppelgänger
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Doppelgänger/Horror Head
+++ b/database/C/Curve/Doppelgänger/Horror Head
@@ -25,5 +25,5 @@ _________________
 Name  Horror Head
 Artist  Curve
 Album  Doppelgänger
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia
 MusicBrainz ID  9c3d05f2-3bcd-4fdf-892c-70d92d04296a

--- a/database/C/Curve/Doppelgänger/Lillies Dying
+++ b/database/C/Curve/Doppelgänger/Lillies Dying
@@ -42,4 +42,4 @@ ___________________
 Name  Lillies Dying
 Artist  Curve
 Album  Doppelgänger
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Doppelgänger/Sandpit
+++ b/database/C/Curve/Doppelgänger/Sandpit
@@ -44,4 +44,4 @@ _____________
 Name  Sandpit
 Artist  Curve
 Album  Doppelgänger
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Doppelgänger/Split Into Fractions
+++ b/database/C/Curve/Doppelgänger/Split Into Fractions
@@ -49,4 +49,4 @@ __________________________
 Name  Split Into Fractions
 Artist  Curve
 Album  Doppelgänger
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Gift/Gift
+++ b/database/C/Curve/Gift/Gift
@@ -70,4 +70,4 @@ __________
 Name  Gift
 Artist  Curve
 Album  Gift
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Gift/Hung Up
+++ b/database/C/Curve/Gift/Hung Up
@@ -90,4 +90,4 @@ _____________
 Name  Hung Up
 Artist  Curve
 Album  Gift
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Gift/Polaroid
+++ b/database/C/Curve/Gift/Polaroid
@@ -52,4 +52,4 @@ ______________
 Name  Polaroid
 Artist  Curve
 Album  Gift
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Open Day at The Hate Fest/Storm
+++ b/database/C/Curve/Open Day at The Hate Fest/Storm
@@ -35,4 +35,4 @@ ___________
 Name  Storm
 Artist  Curve
 Album  Open Day at The Hate Fest
-Written by  Toni Halliday
+Original text by  Toni Halliday

--- a/database/C/Curve/Open Day at The Hate Fest/You Don't Know
+++ b/database/C/Curve/Open Day at The Hate Fest/You Don't Know
@@ -66,4 +66,4 @@ ____________________
 Name  You Don't Know
 Artist  Curve
 Album  Open Day at The Hate Fest
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Pubic Fruit/Blindfold
+++ b/database/C/Curve/Pubic Fruit/Blindfold
@@ -71,7 +71,7 @@ __________
 Name  Blindfold
 Artist  Curve
 Album  Pubic Fruit
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia
 MusicBrainz ID  45ae13e8-c36a-4714-a8bc-69c58c158952
 Copyright  Sony/ATV Music Publishing LLC,  Universal Music Publishing Group,
   BMG Rights Management

--- a/database/C/Curve/Pubic Fruit/Clipped
+++ b/database/C/Curve/Pubic Fruit/Clipped
@@ -42,5 +42,5 @@ _____________
 Name  Clipped
 Artist  Curve
 Album  Pubic Fruit
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia
 MusicBrainz ID  49e2f9b4-9fdf-434e-b961-4a8f49720b06

--- a/database/C/Curve/Pubic Fruit/Coast Is Clear
+++ b/database/C/Curve/Pubic Fruit/Coast Is Clear
@@ -49,4 +49,4 @@ ____________________
 Name  Coast Is Clear
 Artist  Curve
 Album  Pubic Fruit
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Pubic Fruit/Galaxy
+++ b/database/C/Curve/Pubic Fruit/Galaxy
@@ -53,4 +53,4 @@ ____________
 Name  Galaxy
 Artist  Curve
 Album  Pubic Fruit
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia

--- a/database/C/Curve/Superblaster/Low and Behold
+++ b/database/C/Curve/Superblaster/Low and Behold
@@ -44,5 +44,5 @@ ____________________
 Name  Low and Behold
 Artist  Curve
 Album  Superblaster
-Written by  Toni Halliday,  Dean Garcia
+Original text by  Toni Halliday,  Dean Garcia
 MusicBrainz ID  67784773-b82f-4037-8a7f-b798b3234c3b

--- a/database/C/Curve/The New Adventures Of Curve/Signals and Alibis
+++ b/database/C/Curve/The New Adventures Of Curve/Signals and Alibis
@@ -68,4 +68,4 @@ _________________________
 Name  Signals and Alibis
 Artist  Curve
 Album  The New Adventures Of Curve
-Written by  Toni Halliday
+Original text by  Toni Halliday

--- a/database/D/Damageplan/New Found Power/Blink Of An Eye
+++ b/database/D/Damageplan/New Found Power/Blink Of An Eye
@@ -43,6 +43,6 @@ _____________________
 Name  Blink Of An Eye
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Blunt Force Trauma
+++ b/database/D/Damageplan/New Found Power/Blunt Force Trauma
@@ -60,6 +60,6 @@ ________________________
 Name  Blunt Force Trauma
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Breathing New Life
+++ b/database/D/Damageplan/New Found Power/Breathing New Life
@@ -68,6 +68,6 @@ ________________________
 Name  Breathing New Life
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Cold Blooded
+++ b/database/D/Damageplan/New Found Power/Cold Blooded
@@ -97,6 +97,6 @@ __________________
 Name  Cold Blooded
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Crawl
+++ b/database/D/Damageplan/New Found Power/Crawl
@@ -56,6 +56,6 @@ ___________
 Name  Crawl
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Explode
+++ b/database/D/Damageplan/New Found Power/Explode
@@ -41,6 +41,6 @@ _____________
 Name  Explode
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Fuck You
+++ b/database/D/Damageplan/New Found Power/Fuck You
@@ -90,6 +90,6 @@ ______________
 Name  Fuck You
 Artist  Damageplan
 Album  New Found Power
-Written by  Corey Taylor,  Darrell Abbott,
+Original text by  Corey Taylor,  Darrell Abbott,
   Patrick Lachman,  Vincent Abbott
 Copyright  Sony/ATV Music Publishing LLC

--- a/database/D/Damageplan/New Found Power/Moment Of Truth
+++ b/database/D/Damageplan/New Found Power/Moment Of Truth
@@ -47,6 +47,6 @@ _____________________
 Name  Moment Of Truth
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/New Found Power
+++ b/database/D/Damageplan/New Found Power/New Found Power
@@ -50,6 +50,6 @@ _____________________
 Name  New Found Power
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Pride
+++ b/database/D/Damageplan/New Found Power/Pride
@@ -44,6 +44,6 @@ ___________
 Name  Pride
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Reborn
+++ b/database/D/Damageplan/New Found Power/Reborn
@@ -67,6 +67,6 @@ ____________
 Name  Reborn
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Save Me
+++ b/database/D/Damageplan/New Found Power/Save Me
@@ -46,6 +46,6 @@ _____________
 Name  Save Me
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Soul Bleed
+++ b/database/D/Damageplan/New Found Power/Soul Bleed
@@ -42,6 +42,6 @@ ________________
 Name  Soul Bleed
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Damageplan/New Found Power/Wake Up
+++ b/database/D/Damageplan/New Found Power/Wake Up
@@ -82,6 +82,6 @@ _____________
 Name  Wake Up
 Artist  Damageplan
 Album  New Found Power
-Written by  Darrell Lance Abbott,  Patrick A. Lachman,
+Original text by  Darrell Lance Abbott,  Patrick A. Lachman,
   Vincent Paul Abbott
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Disturbed/Believe/Devour
+++ b/database/D/Disturbed/Believe/Devour
@@ -52,6 +52,6 @@ ____________
 Name  Devour
 Artist  Disturbed
 Album  Believe
-Written by  Dan Donegan,  David Draiman,
+Original text by  Dan Donegan,  David Draiman,
   Michael Wengren,  Mike Wengren,  Steve Kmak
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Disturbed/Believe/Remember
+++ b/database/D/Disturbed/Believe/Remember
@@ -47,6 +47,6 @@ ______________
 Name  Remember
 Artist  Disturbed
 Album  Believe
-Written by  Dan Donegan,  David Draiman,
+Original text by  Dan Donegan,  David Draiman,
   Michael Wengren,  Mike Wengren,  Steve Kmak
 Copyright  Warner/Chappell Music, Inc

--- a/database/D/Donna Summer/She Works Hard for the Money/She Works Hard for the Money
+++ b/database/D/Donna Summer/She Works Hard for the Money/She Works Hard for the Money
@@ -75,5 +75,5 @@ So you better treat her right.
 __________________________________
 Name  She Works Hard for the Money
 Artist  Donna Summer
-Written by  Donna Summer,  Michael Omartian
+Original text by  Donna Summer,  Michael Omartian
 Copyright  Universal Music Publishing Group

--- a/database/E/Enigma/MCMXC a.D./Back To The Rivers Of Belief: The Rivers Of Belief
+++ b/database/E/Enigma/MCMXC a.D./Back To The Rivers Of Belief: The Rivers Of Belief
@@ -22,5 +22,5 @@ ________________________________________________________
 Name  Back To The Rivers Of Belief: The Rivers Of Belief
 Artist  Enigma
 Album  MCMXC a.D.
-Written by  David Fairstein,  M.C. Curly
+Original text by  David Fairstein,  M.C. Curly
 Copyright  Sony/ATV Music Publishing LLC

--- a/database/F/Front Line Assembly/Virgin Voices: A Tribute to Madonna, Volume One/Justify My Love
+++ b/database/F/Front Line Assembly/Virgin Voices: A Tribute to Madonna, Volume One/Justify My Love
@@ -44,7 +44,7 @@ __________________________________________________________________
 Name  Justify My Love
 Artist  Front Line Assembly
 Album  Virgin Voices: A Tribute to Madonna, Volume One
-Written by  Madonna Ciccone,  Lenny Albert Kravitz,  Ingrid Chavez
+Original text by  Madonna Ciccone,  Lenny Albert Kravitz,  Ingrid Chavez
 Copyright  WB Music Corp.,  S.I.A.E. Direzione Generale,  Webo Girl Publishing Inc.,
   Reach Music Publishing-digital,  Reach Global Inc.,  Skyfish Music,
   Miss Bessie Music,  Warner Chappell Music France,  Universal Music Corporation,

--- a/database/G/Garbage/Version 2.0/Push It
+++ b/database/G/Garbage/Version 2.0/Push It
@@ -71,7 +71,7 @@ __________________
 Name  Push It
 Artist  Garbage
 Album  Version 2.0
-Written by  Douglas Elwin Erickson,  Shirley Ann Manson,
+Original text by  Douglas Elwin Erickson,  Shirley Ann Manson,
   Steve W. Marker,  Bryan David Vig
 Copyright  Kobalt Music Publishing Ltd.,
   Universal Music Publishing Group

--- a/database/G/Garbage/Version 2.0/Sleep Together
+++ b/database/G/Garbage/Version 2.0/Sleep Together
@@ -53,6 +53,6 @@ Name  Sleep Together
 Artist  Garbage
 Album  Version 2.0
 MusicBrainz ID  26dffa2b-642a-4dfd-94f9-8fc9b69cdb28
-Written by  Douglas Elwin Erickson,  Shirley Ann Manson,  Steve W. Marker,
+Original text by  Douglas Elwin Erickson,  Shirley Ann Manson,  Steve W. Marker,
   Bryan David Vig
 Copyright  Kobalt Music Publishing Ltd.,  Universal Music Publishing Group

--- a/database/G/Godhead/2000 Years of Human Error/Backstander
+++ b/database/G/Godhead/2000 Years of Human Error/Backstander
@@ -38,6 +38,6 @@ _________________
 Name  Backstander
 Artist  Godhead
 Album 2000 Years of Human Error
-Written by  James M. O'connor,  Jason Charles Miller,
+Original text by  James M. O'connor,  Jason Charles Miller,
   Michael K. Miller,  Ullrich Gerd Hepperlin
 Copyright  Warner/Chappell Music, Inc

--- a/database/G/Godhead/2000 Years of Human Error/I Hate Today
+++ b/database/G/Godhead/2000 Years of Human Error/I Hate Today
@@ -32,6 +32,6 @@ __________________
 Name  I Hate Today
 Artist  Godhead
 Album  2000 Years of Human Error
-Written by  Miller, Jason Charles,
+Original text by  Miller, Jason Charles,
   Hepperlin, Ullrich Gerd,  Miller, Michael K.,
   O'Connor, James M.

--- a/database/G/Godhead/2000 Years of Human Error/Sinking
+++ b/database/G/Godhead/2000 Years of Human Error/Sinking
@@ -56,5 +56,5 @@ _____________
 Name  Sinking
 Artist  Godhead
 Album  2000 Years of Human Error
-Written by  Miller, Jason Charles,  Hepperlin, Ullrich Gerd,
+Original text by  Miller, Jason Charles,  Hepperlin, Ullrich Gerd,
   Miller, Michael K.,  O'Connor, James M.

--- a/database/G/Godhead/2000 Years of Human Error/Tired Old Man
+++ b/database/G/Godhead/2000 Years of Human Error/Tired Old Man
@@ -37,6 +37,6 @@ ___________________
 Name  Tired Old Man
 Artist  Godhead
 Album  2000 Years of Human Error
-Written by  Miller, Jason Charles,
+Original text by  Miller, Jason Charles,
   Hepperlin, Ullrich Gerd,  Miller, Michael K.,
   O'Connor, James M.

--- a/database/G/Godhead/Power Tool Stigmata/Afterthoughts
+++ b/database/G/Godhead/Power Tool Stigmata/Afterthoughts
@@ -33,5 +33,5 @@ ___________________
 Name  Afterthoughts
 Artist  Godhead
 Album  Power Tool Stigmata
-Written by  Miller, Jason Charles,
+Original text by  Miller, Jason Charles,
   Hepperlin, Ullrich Gerd

--- a/database/G/Godhead/Power Tool Stigmata/Alone
+++ b/database/G/Godhead/Power Tool Stigmata/Alone
@@ -29,5 +29,5 @@ ___________
 Name  Alone
 Artist  Godhead
 Album  Power Tool Stigmata
-Written by  Dubois, Charles,
+Original text by  Dubois, Charles,
   Miller, Lee,  Rucker, Darius

--- a/database/G/Godhead/Power Tool Stigmata/Bleed
+++ b/database/G/Godhead/Power Tool Stigmata/Bleed
@@ -28,7 +28,7 @@ ___________
 Name  Bleed
 Artist  Godhead
 Album  Power Tool Stigmata
-Written by  Fisher, Carl T,
+Original text by  Fisher, Carl T,
   McLellan, Neil,
   Howe, Christopher,
   Miller, Nigel

--- a/database/G/Godhead/Power Tool Stigmata/Lies
+++ b/database/G/Godhead/Power Tool Stigmata/Lies
@@ -45,7 +45,7 @@ __________
 Name  Lies
 Artist  Godhead
 Album  Power Tool Stigmata
-Written by  Kreviazuk, Chantal,
+Original text by  Kreviazuk, Chantal,
   Maida, Raine,
   Miller, Jordan,
   Miller, Kylie

--- a/database/G/Godsmack/Faceless/Serenity
+++ b/database/G/Godsmack/Faceless/Serenity
@@ -53,5 +53,5 @@ ______________
 Name  Serenity
 Artist  Godsmack
 Album  Faceless
-Written by  Salvatore P. Erna
+Original text by  Salvatore P. Erna
 Copyright  Universal Music Publishing Group

--- a/database/G/Godsmack/IV/Hollow
+++ b/database/G/Godsmack/IV/Hollow
@@ -35,6 +35,6 @@ ____________
 Name  Hollow
 Artist  Godsmack
 Album  IV
-Written by  James Shannon Larkin,  Rob Merrill,
+Original text by  James Shannon Larkin,  Rob Merrill,
   Salvatore P. Erna, Tony Rombola
 Copyright  Universal Music Publishing Group

--- a/database/G/Godsmack/IV/One Rainy Day
+++ b/database/G/Godsmack/IV/One Rainy Day
@@ -45,6 +45,6 @@ ___________________
 Name  One Rainy Day
 Artist  Godsmack
 Album  IV
-Written by  James Shannon Larkin,  Rob Merrill,
+Original text by  James Shannon Larkin,  Rob Merrill,
   Salvatore P. Erna,  Tony Rombola
 Copyright  Universal Music Publishing Group

--- a/database/I/INXS/Shabooh Shoobah/Soul Mistake
+++ b/database/I/INXS/Shabooh Shoobah/Soul Mistake
@@ -45,7 +45,7 @@ __________________
 Name  Soul Mistake
 Artist  INXS
 Album  Shabooh Shoobah
-Written by  Michael Kelland Hutchence,
+Original text by  Michael Kelland Hutchence,
   Andrew Charles Farriss
 Copyright  Peermusic Publishing,
   Universal Music Publishing Group

--- a/database/I/INXS/Shabooh Shoobah/The One Thing
+++ b/database/I/INXS/Shabooh Shoobah/The One Thing
@@ -33,6 +33,6 @@ ___________________
 Name  The One Thing
 Artist  INXS
 Album  Shabooh Shoobah
-Written by  Andrew Charles Farriss,
+Original text by  Andrew Charles Farriss,
   Michael Hutchence
 Copyright  Universal Music Publishing Group

--- a/database/I/INXS/Shabooh Shoobah/To Look At You
+++ b/database/I/INXS/Shabooh Shoobah/To Look At You
@@ -60,5 +60,5 @@ ____________________
 Name  To Look At You
 Artist  INXS
 Album  Shabooh Shoobah
-Written by  Andrew Charles Farriss
+Original text by  Andrew Charles Farriss
 Copyright  Universal Music Publishing Group

--- a/database/J/Jerkstore/Jerks Rule!!/Crazy
+++ b/database/J/Jerkstore/Jerks Rule!!/Crazy
@@ -62,4 +62,4 @@ ___________
 Name  Crazy
 Artist  Jerkstore
 Album  Jerks Rule!!
-Written by  Jerkstore
+Original text by  Jerkstore

--- a/database/K/KMFDM/Adios/Today
+++ b/database/K/KMFDM/Adios/Today
@@ -46,4 +46,4 @@ ___________
 Name  Today
 Artist  KMFDM
 Album  Adios
-Written by  Sascha Konietzko,  Tim Skold
+Original text by  Sascha Konietzko,  Tim Skold

--- a/database/K/KMFDM/Symbols/Stray Bullet
+++ b/database/K/KMFDM/Symbols/Stray Bullet
@@ -104,4 +104,4 @@ __________________
 Name  Stray Bullet
 Artist  KMFDM
 Album  Symbols
-Written by  Sascha Konietzko,  Gunter Schultz,  En Esch
+Original text by  Sascha Konietzko,  Gunter Schultz,  En Esch

--- a/database/L/L7/Bricks Are Heavy/Shitlist
+++ b/database/L/L7/Bricks Are Heavy/Shitlist
@@ -29,5 +29,5 @@ ______________
 Name  Shitlist
 Artist  L7
 Album  Bricks Are Heavy
-Written by  Donita Sparks
+Original text by  Donita Sparks
 Copyright  Universal Music Publishing Group,  BMG Rights Management

--- a/database/M/Ministry/Dark Side of the Spoon/KAIF
+++ b/database/M/Ministry/Dark Side of the Spoon/KAIF
@@ -32,6 +32,6 @@ ________________
 Name  KAIF
 Artist  Ministry
 Album  Dark Side of the Spoon
-Written by  Allen Jourgensen,  Louis James Svitek Jr,
+Original text by  Allen Jourgensen,  Louis James Svitek Jr,
   Paul G. Barker,  Reynolds Washam
 Copyright  Warner/Chappell Music, Inc

--- a/database/N/Nina/Sleepwalking/Beyond Memory
+++ b/database/N/Nina/Sleepwalking/Beyond Memory
@@ -60,4 +60,4 @@ ___________________
 Name  Beyond Memory
 Artist  NINA
 Album  Sleepwalking
-Written by  N. Boldt,  L. Fares,  L. Simpkins,  E. Gamper
+Original text by  N. Boldt,  L. Fares,  L. Simpkins,  E. Gamper

--- a/database/N/Nitzer Ebb/As Is/Come Alive
+++ b/database/N/Nitzer Ebb/As Is/Come Alive
@@ -59,5 +59,5 @@ _________________
 Name  Come Alive
 Artist  Nitzer Ebb
 Album  As Is
-Written by  Jepther Washington Mcclymont,  Homer Harris
+Original text by  Jepther Washington Mcclymont,  Homer Harris
 Copyright  The Royalty Network Inc.

--- a/database/N/Nitzer Ebb/Industrial Complex/I Am Undone (Alan Wilder Remix)
+++ b/database/N/Nitzer Ebb/Industrial Complex/I Am Undone (Alan Wilder Remix)
@@ -54,5 +54,5 @@ __________________________________
 Name  I Am Undone (Alan Wilder Remix)
 Artist  Nitzer Ebb
 Album  Industrial Complex
-Written by  Vaughan Harris,  Douglas John Mc Carthy
+Original text by  Vaughan Harris,  Douglas John Mc Carthy
 Copyright  Edition Triggertraxx,  Warner Chappell Music France

--- a/database/N/Nitzer Ebb/Industrial Complex/Once You Say
+++ b/database/N/Nitzer Ebb/Industrial Complex/Once You Say
@@ -96,5 +96,5 @@ Name  Once You Say
 Album  Industrial Complex
 Artist  Nitzer Ebb
 Track  2
-Written by  Vaughan Harris,  Douglas John Mc Carthy
+Original text by  Vaughan Harris,  Douglas John Mc Carthy
 Copyright  Edition Triggertraxx

--- a/database/O/Ohgr/Sunnypsyop/Jako
+++ b/database/O/Ohgr/Sunnypsyop/Jako
@@ -42,4 +42,4 @@ Name  JaKO
 Artist  ohGr
 Album  SunnyPsyOp
 Year  2003
-Written by  Kevin Ogilvie,  Mark Walk
+Original text by  Kevin Ogilvie,  Mark Walk

--- a/database/O/Oleander/Joyride/Runaway Train
+++ b/database/O/Oleander/Joyride/Runaway Train
@@ -42,6 +42,6 @@ Album  Joyride
 Track no  11
 Year  2003
 MusicBrainz ID  29f4ca0c-6e1e-4e1b-a850-983e542f7e5a
-Written by  Douglas James Eldridge,  Richard C. Ivanisevich,
+Original text by  Douglas James Eldridge,  Richard C. Ivanisevich,
   Thomas Allan Flowers
 Copyright  Universal Music Publishing Group

--- a/database/O/Otis Taylor/Respect the Dead/Ten Million Slaves
+++ b/database/O/Otis Taylor/Respect the Dead/Ten Million Slaves
@@ -58,4 +58,4 @@ _______________________
 Name  Ten Million Slaves
 Artist  Otis Taylor,  Cassie Taylor
 Album  Respect the Deads
-Written by  Otis Taylor
+Original text by  Otis Taylor

--- a/database/P/Pantera/Vulgar Display of Power/This Love
+++ b/database/P/Pantera/Vulgar Display of Power/This Love
@@ -52,6 +52,6 @@ _______________
 Name  This Love
 Artist  Pantera
 Album  Vulgar Display of Power
-Written by  Vincent Paul Abbott,  Darrell Lance Abbott,
+Original text by  Vincent Paul Abbott,  Darrell Lance Abbott,
   Rex Brown,  Philip Anselmo
 Copyright  Roba Music,  Warner/Chappell Music, Inc

--- a/database/P/Peaches/The Teaches of Peaches/Fuck The Pain Away
+++ b/database/P/Peaches/The Teaches of Peaches/Fuck The Pain Away
@@ -58,5 +58,5 @@ ______________
 Name  Fuck The Pain Away
 Album  The Teaches Of Peaches
 Artist  Peaches
-Written by  Merrill Nisker
+Original text by  Merrill Nisker
 Copyright  Kobalt Music Publishing Ltd.

--- a/database/P/Perturbator/Dangerous Days/Hard Wired (feat. Memory Ghost's Isabella Goloversic)
+++ b/database/P/Perturbator/Dangerous Days/Hard Wired (feat. Memory Ghost's Isabella Goloversic)
@@ -66,4 +66,4 @@ ________________
 Name  Hard Wired
 Artist  Perturbator,  Isabella Goloversic
 Album  Dangerous Days
-Written by  Isabella Goloversic
+Original text by  Isabella Goloversic

--- a/database/P/Perturbator/I Am The Night/Desire (feat. Greta Link)
+++ b/database/P/Perturbator/I Am The Night/Desire (feat. Greta Link)
@@ -32,4 +32,4 @@ ____________
 Name  Desire
 Artist  Perturbator,  Greta Link
 Album  I Am The Night
-Written by  Greta Link
+Original text by  Greta Link

--- a/database/P/Perturbator/I Am The Night/Naked Tongues (feat. Memory Ghost's Isabella Goloversic)
+++ b/database/P/Perturbator/I Am The Night/Naked Tongues (feat. Memory Ghost's Isabella Goloversic)
@@ -86,4 +86,4 @@ ___________________
 Name  Naked Tongues
 Artist  Perturbator,  Isabella Goloversic
 Album  I Am The Night
-Written by  Isabella Goloversic
+Original text by  Isabella Goloversic

--- a/database/P/Prurient/Bermuda Drain/A Meal Can Be Made
+++ b/database/P/Prurient/Bermuda Drain/A Meal Can Be Made
@@ -38,4 +38,4 @@ Name  A Meal Can Be Made
 Artist  Prurient
 Album  Bermuda Drain
 Track no  2
-Written by  Dominick Fernow
+Original text by  Dominick Fernow

--- a/database/P/Prurient/Bermuda Drain/Bermuda Drain
+++ b/database/P/Prurient/Bermuda Drain/Bermuda Drain
@@ -33,5 +33,5 @@ Name  Bermuda Drain
 Artist  Prurient
 Album  Bermuda Drain
 Track no  3
-Written by  Dominick Fernow
+Original text by  Dominick Fernow
 MusicBrainz ID  008c5fbc-ae23-4f2c-8cec-50ac80a9cafe

--- a/database/P/Prurient/Bermuda Drain/Let's Make a Slave
+++ b/database/P/Prurient/Bermuda Drain/Let's Make a Slave
@@ -27,4 +27,4 @@ Name  Let's Make a Slave
 Artist  Prurient
 Album  Bermuda Drain
 Track no  7
-Written by  Dominick Fernow
+Original text by  Dominick Fernow

--- a/database/P/Prurient/Bermuda Drain/Many Jewels Surround the Crown
+++ b/database/P/Prurient/Bermuda Drain/Many Jewels Surround the Crown
@@ -32,5 +32,5 @@ Name  Many Jewels Surround the Crown
 Artist  Prurient
 Album  Bermuda Drain
 Track no  1
-Written by  Dominick Fernow
+Original text by  Dominick Fernow
 MusicBrainz ID  e295d03d-7b9f-4209-8ae7-228c6872b51d

--- a/database/P/Prurient/Bermuda Drain/Myth of Sex
+++ b/database/P/Prurient/Bermuda Drain/Myth of Sex
@@ -18,4 +18,4 @@ Name  Myth of Sex
 Artist  Prurient
 Album  Bermuda Drain
 Track no  8
-Written by  Dominick Fernow
+Original text by  Dominick Fernow

--- a/database/P/Prurient/Bermuda Drain/Palm Tree Corpse
+++ b/database/P/Prurient/Bermuda Drain/Palm Tree Corpse
@@ -23,5 +23,5 @@ Name  Palm Tree Corpse
 Artist  Prurient
 Album  Bermuda Drain
 Track no  5
-Written by  Dominick Fernow
+Original text by  Dominick Fernow
 MusicBrainz ID  97a13a61-95dc-4c37-bf23-db28ba030d9e

--- a/database/P/Prurient/Bermuda Drain/Sugar Cane Chapel
+++ b/database/P/Prurient/Bermuda Drain/Sugar Cane Chapel
@@ -57,4 +57,4 @@ Name  Sugar Cane Chapel
 Artist  Prurient
 Album  Bermuda Drain
 Track no  9
-Written by  Dominick Fernow
+Original text by  Dominick Fernow

--- a/database/P/Prurient/Bermuda Drain/There Are Still Secrets
+++ b/database/P/Prurient/Bermuda Drain/There Are Still Secrets
@@ -25,4 +25,4 @@ Name  There Are Still Secrets
 Artist  Prurient
 Album  Bermuda Drain
 Track no  6
-Written by  Dominick Fernow
+Original text by  Dominick Fernow

--- a/database/P/Prurient/Bermuda Drain/Watch Silently
+++ b/database/P/Prurient/Bermuda Drain/Watch Silently
@@ -52,4 +52,4 @@ Name  Watch Silently
 Artist  Prurient
 Album  Bermuda Drain
 Track no  4
-Written by  Dominick Fernow
+Original text by  Dominick Fernow

--- a/database/P/Prurient/Time's Arrow/Time's Arrow
+++ b/database/P/Prurient/Time's Arrow/Time's Arrow
@@ -19,5 +19,5 @@ Name  Time's Arrow
 Artist  Prurient
 Album  Time's Arrow
 Year  2011
-Written by  Dominick Fernow
+Original text by  Dominick Fernow
 MusicBrainz ID  7719e631-fd39-4d6a-9abd-d52eb426b2ea

--- a/database/R/Recoil/Bloodline/Edge To Life
+++ b/database/R/Recoil/Bloodline/Edge To Life
@@ -68,4 +68,4 @@ __________________
 Name  Edge To Life
 Artist  Recoil
 Album  Bloodline
-Written by  Toni Halliday,  Alan Wilder
+Original text by  Toni Halliday,  Alan Wilder

--- a/database/R/Revolting Cocks/Beers, Steers & Queers/Stainless Steel Providers
+++ b/database/R/Revolting Cocks/Beers, Steers & Queers/Stainless Steel Providers
@@ -66,7 +66,7 @@ __________________________________________________
 Name  Stainless Steel Providers
 Artist  Revolting Cocks
 Album  Beers, Steers & Queers
-Written by  Christopher Connelly,  Paul G. Barker,
+Original text by  Christopher Connelly,  Paul G. Barker,
   Allen Jourgensen,  William Riefflin,  Luc Van Acker
 Copyright  Warner/Chappell Music, Inc,
   Universal Music Publishing Group

--- a/database/R/Revolting Cocks/Linger Ficken' Good ... And Other Barnyard Oddities/Mr. Lucky
+++ b/database/R/Revolting Cocks/Linger Ficken' Good ... And Other Barnyard Oddities/Mr. Lucky
@@ -44,6 +44,6 @@ __________________________________________________
 Name  Mr. Lucky
 Artist  Revolting Cocks
 Album  Linger Ficken' Good ... And Other Barnyard Oddities
-Written by  Christopher Connelly,  Paul G. Barker,
+Original text by  Christopher Connelly,  Paul G. Barker,
   Allen Jourgensen,  William Riefflin,  Roland Barker
 Copyright  Warner/Chappell Music, Inc,  The Bicycle Music Company

--- a/database/R/Revolting Cocks/Sex-O Olympic-O/Red Parrot
+++ b/database/R/Revolting Cocks/Sex-O Olympic-O/Red Parrot
@@ -75,5 +75,5 @@ ________________
 Name  Red Parrot
 Artist  Revolting Cocks
 Album  Sex-O Olympic-O
-Written by  Al Jourgensen,  Sinhue Quirin,
+Original text by  Al Jourgensen,  Sinhue Quirin,
   Joshua David Bradford

--- a/database/R/Rush/Counterparts/Cold Fire
+++ b/database/R/Rush/Counterparts/Cold Fire
@@ -92,5 +92,5 @@ Artist  Rush
 Album  Counterparts
 Year  1993
 MusicBrainz ID  0654ab32-08e5-47dd-b3df-0ab10552ad68
-Written by  Neil Elwood Peart
+Original text by  Neil Elwood Peart
 Copyright  Ole Media Management Lp

--- a/database/R/Röyksopp/The Understanding/What Else Is There?
+++ b/database/R/Röyksopp/The Understanding/What Else Is There?
@@ -48,7 +48,7 @@ _________________________
 Name  What Else Is There?
 Artist  Röyksopp
 Album  The Understanding
-Written by  Danny Shoshan,  Robert Huxley,
+Original text by  Danny Shoshan,  Robert Huxley,
   Roger Greenaway,  Svein Berge,  Tobjor Brundtland,
   Karin Dreiger,  Olaf Dreiger,  Tony Macauley
 Copyright  Kobalt Music Publishing Ltd.,

--- a/database/S/Shakespears Sister/Sacred Heart/Heaven is in Your Arms
+++ b/database/S/Shakespears Sister/Sacred Heart/Heaven is in Your Arms
@@ -59,7 +59,7 @@ ____________________________
 Name  Heaven is in Your Arms
 Artist  Shakespears Sister
 Album  Sacred Heart
-Written by  David Allan Stewart,
+Original text by  David Allan Stewart,
   Michael Arnold Kamen,  Marcella Levy,
   Siobhan Maire Deirdre Fahey,  Richard G Feldman
 Copyright  Universal Music Publishing Mgb Ltd.,

--- a/database/S/Sister Machine Gun/Burn/Burn
+++ b/database/S/Sister Machine Gun/Burn/Burn
@@ -67,6 +67,6 @@ __________________________
 Name  Burn
 Artist  Sister Machine Gun
 Album  Burn
-Written by  Anthony St. Aubyn Kelly,  Wayne Burton Passley,
+Original text by  Anthony St. Aubyn Kelly,  Wayne Burton Passley,
   Mark Anthony Wolfe,  Christopher S. Birch,  Maurice Gregory
 Copyright  Universal Music Publishing Group

--- a/database/S/Skinny Puppy/Cleanse Fold and Manipulate/Addiction
+++ b/database/S/Skinny Puppy/Cleanse Fold and Manipulate/Addiction
@@ -59,5 +59,5 @@ _______________
 Name  Addiction
 Artist  Skinny Puppy
 Album  Cleanse Fold and Manipulate
-Written by  Kevin Ogilvie
+Original text by  Kevin Ogilvie
 MusicBrainz ID  cc8844aa-7db0-419b-8bfe-7147a9f367ab

--- a/database/S/Skinny Puppy/Mind: The Perpetual Intercourse/One Time One Place
+++ b/database/S/Skinny Puppy/Mind: The Perpetual Intercourse/One Time One Place
@@ -94,5 +94,5 @@ ________________________
 Name  One Time One Place
 Artist  Skinny Puppy
 Album  Mind: The Perpetual Intercourse
-Written by  cEvin Key,  Ogre
+Original text by  cEvin Key,  Ogre
 MusicBrainz ID  2c4519c6-6549-450d-a44f-0173a35555b8

--- a/database/S/Skinny Puppy/The Greater Wrong of the Right/Past Present
+++ b/database/S/Skinny Puppy/The Greater Wrong of the Right/Past Present
@@ -66,4 +66,4 @@ ____________________
 Name  Past Present
 Artist  Skinny Puppy
 Album  The Greater Wrong of the Right
-Written by  Kevin Ogilvie,  Mark Walk,  Kevin Crompton
+Original text by  Kevin Ogilvie,  Mark Walk,  Kevin Crompton

--- a/database/S/Skinny Puppy/VIVIsectVI/Testure
+++ b/database/S/Skinny Puppy/VIVIsectVI/Testure
@@ -49,5 +49,5 @@ _____________
 Name  Testure
 Artist  Skinny Puppy
 Album  VIVIsectVI
-Written by  Dwayne Rudolph Goettel,  cEvin Key,  Dave Ogilvie,  Ogre
+Original text by  Dwayne Rudolph Goettel,  cEvin Key,  Dave Ogilvie,  Ogre
 MusicBrainz ID  8fd71584-bb22-4985-9154-0a49618314e7

--- a/database/S/Stone Sour/Come What(ever) May/Hell & Consequences
+++ b/database/S/Stone Sour/Come What(ever) May/Hell & Consequences
@@ -40,5 +40,5 @@ _________________________
 Name  Hell & Consequences
 Artist  Stone Sour
 Album  Come What(ever) May
-Written by  Corey Taylor,  James Root,
+Original text by  Corey Taylor,  James Root,
   James Donald Root,  Josh Rand,  Shawn Economaki

--- a/database/S/Stray Cats/Choo Choo Hot Fish/Lust n Love
+++ b/database/S/Stray Cats/Choo Choo Hot Fish/Lust n Love
@@ -65,5 +65,5 @@ ______________________
 Name  Lust n Love
 Artist  Stray Cats
 Album  Choo Choo Hot Fish
-Written by  Bill Carter,  Ruth Ellsworth,  Brian Setzer
+Original text by  Bill Carter,  Ruth Ellsworth,  Brian Setzer
 MusicBrainz ID  265ec78f-b906-407b-a82a-21a9a4517158

--- a/database/T/The Cardigans/Gran Turismo/Erase ∕ Rewind
+++ b/database/T/The Cardigans/Gran Turismo/Erase ∕ Rewind
@@ -35,5 +35,5 @@ ____________________
 Name  Erase / Rewind
 Artist  The Cardigans
 Album  Gran Turismo
-Written by  Nina Persson,  Peter Anders Svensson
+Original text by  Nina Persson,  Peter Anders Svensson
 Copyright  Universal Music Publishing Group

--- a/database/T/The Cardigans/Gran Turismo/My Favourite Game
+++ b/database/T/The Cardigans/Gran Turismo/My Favourite Game
@@ -40,5 +40,5 @@ ______________________
 Name  My Favorite Game
 Artist  The Cardigans
 Album  Gran Turismo
-Written by  Nina Persson,  Peter Anders Svensson
+Original text by  Nina Persson,  Peter Anders Svensson
 Copyright  Universal Music Publishing Group

--- a/database/T/The Last Internationale/We Will Reign/1968
+++ b/database/T/The Last Internationale/We Will Reign/1968
@@ -55,4 +55,4 @@ __________
 Name  1968
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/Battleground
+++ b/database/T/The Last Internationale/We Will Reign/Battleground
@@ -50,4 +50,4 @@ __________________
 Name  Battleground
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/Devil's Dust
+++ b/database/T/The Last Internationale/We Will Reign/Devil's Dust
@@ -70,4 +70,4 @@ __________________
 Name  Devil's Dust
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/Fire
+++ b/database/T/The Last Internationale/We Will Reign/Fire
@@ -75,4 +75,4 @@ __________
 Name  Fire
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/I'll Be Alright
+++ b/database/T/The Last Internationale/We Will Reign/I'll Be Alright
@@ -67,4 +67,4 @@ _____________________
 Name  I'll Be Alright
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/Killing Fields
+++ b/database/T/The Last Internationale/We Will Reign/Killing Fields
@@ -57,4 +57,4 @@ ____________________
 Name  Killing Fields
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/Life, Liberty, And The Pursuit Of Indian Blood
+++ b/database/T/The Last Internationale/We Will Reign/Life, Liberty, And The Pursuit Of Indian Blood
@@ -95,4 +95,4 @@ ____________________________________________________
 Name  Life, Liberty, And The Pursuit Of Indian Blood
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/Wanted Man
+++ b/database/T/The Last Internationale/We Will Reign/Wanted Man
@@ -99,4 +99,4 @@ ________________
 Name  Wanted Man
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Last Internationale/We Will Reign/We Will Reign
+++ b/database/T/The Last Internationale/We Will Reign/We Will Reign
@@ -60,4 +60,4 @@ ___________________
 Name  We Will Reign
 Artist  The Last Internationale
 Album  We Will Reign
-Written by  The Last Internationale
+Original text by  The Last Internationale

--- a/database/T/The Midnight/Endless Summer/Vampires
+++ b/database/T/The Midnight/Endless Summer/Vampires
@@ -25,4 +25,4 @@ Album  Endless Summer
 Track no  8
 Year  2016
 MusicBrainz ID  5ecaf4e8-c19d-4756-b697-20b8478b0c8c
-Written by  Tyler Lyle,  Tim McEwan
+Original text by  Tyler Lyle,  Tim McEwan

--- a/database/T/The Sisters Of Mercy/Floodland/Dominion Mother Russia
+++ b/database/T/The Sisters Of Mercy/Floodland/Dominion Mother Russia
@@ -78,5 +78,5 @@ ______________________________
 Name  Dominion / Mother Russia
 Artist  The Sisters Of Mercy
 Album  Floodland
-Written by  Andrew Eldritch
+Original text by  Andrew Eldritch
 Copyright  1986 EMI Music Publishing Ltd

--- a/database/T/The Sisters Of Mercy/Floodland/Never Land (full length)
+++ b/database/T/The Sisters Of Mercy/Floodland/Never Land (full length)
@@ -64,5 +64,5 @@ ______________________________
 Name  Never Land (full length)
 Artist  The Sisters Of Mercy
 Album  Floodland
-Written by  Andrew Eldritch
+Original text by  Andrew Eldritch
 MusicBrainz ID  6d295459-a7e3-4b3a-8a28-94e4051e76b8

--- a/database/T/The Sisters Of Mercy/Vision Thing/Doctor Jeep
+++ b/database/T/The Sisters Of Mercy/Vision Thing/Doctor Jeep
@@ -54,5 +54,5 @@ _________________
 Name  Doctor Jeep
 Album  Vision Thing
 Artist  The Sisters Of Mercy
-Written by  Andreas Bruhn,  Andrew Taylor
+Original text by  Andreas Bruhn,  Andrew Taylor
 Copyright  Sony/ATV Music Publishing LLC

--- a/database/T/The Sisters Of Mercy/Vision Thing/More
+++ b/database/T/The Sisters Of Mercy/Vision Thing/More
@@ -93,4 +93,4 @@ __________
 Name  More
 Album  Vision Thing
 Artist  The Sisters Of Mercy
-Written by  Jim Steinman,  Andrew Eldritch
+Original text by  Jim Steinman,  Andrew Eldritch

--- a/database/T/Tool/Lateralus/The Grudge
+++ b/database/T/Tool/Lateralus/The Grudge
@@ -59,7 +59,7 @@ ________________
 Name  The Grudge
 Artist  Tool
 Album  The Grudge
-Written by  Adam Jones,  Daniel Carey,
+Original text by  Adam Jones,  Daniel Carey,
   Justin Gunner Chancellor,  Maynard James Keenan
 Copyright  Warner/Chappell Music, Inc.,
   BMG Rights Management (US), LLC

--- a/database/T/Tool/Opiate/Sweat
+++ b/database/T/Tool/Opiate/Sweat
@@ -50,6 +50,6 @@ ___________
 Name  Sweat
 Artist  Tool
 Album  Opiate
-Written by  Adam Jones,  Daniel Carey,
+Original text by  Adam Jones,  Daniel Carey,
   Maynard James Keenan,  Paul D'Amour
 Copyright  BMG Rights Management US, LLC

--- a/database/T/Tool/Ænima/H.
+++ b/database/T/Tool/Ænima/H.
@@ -74,7 +74,7 @@ ________
 Name  H.
 Artist  Tool
 Album  Ænima
-Written by  Daniel Carey,  Maynard Keenan,
+Original text by  Daniel Carey,  Maynard Keenan,
   Adam Jones,  Paul D'Amour
 Copyright  BMG Gold Songs,  Emi Virgin Music Inc.,
   Toolshed Music, Emi Music Publishing France,

--- a/database/T/Tool/Ænima/Ænema
+++ b/database/T/Tool/Ænima/Ænema
@@ -99,7 +99,7 @@ ___________
 Name  Ænema
 Artist  Tool
 Album  Ænima
-Written by  Daniel Carey (P/K/A "TOOL"),
+Original text by  Daniel Carey (P/K/A "TOOL"),
   J. Chancellor,  Adam Thomas Jones,
   James Herbert Keenan
 Copyright  EMI Music Publishing

--- a/database/T/Tricky/Blowback/Excess
+++ b/database/T/Tricky/Blowback/Excess
@@ -79,5 +79,5 @@ _________________
 Name  Excess
 Artist  Tricky
 Album  Blowback
-Written by  Adrian Nicholas Matthew Thaws
+Original text by  Adrian Nicholas Matthew Thaws
 Copyright  Universal Music Publishing Group

--- a/database/T/Type O Negative/Bloody Kisses/Blood & Fire
+++ b/database/T/Type O Negative/Bloody Kisses/Blood & Fire
@@ -42,5 +42,5 @@ __________________
 Name  Blood & Fire
 Artist  Type O Negative
 Album  Bloody Kisses
-Written by  Peter Thomas Steele
+Original text by  Peter Thomas Steele
 MusicBrainz ID  10148be8-e09b-45bf-a897-314cd8281250

--- a/database/T/Type O Negative/Life Is Killing Me/Nettie
+++ b/database/T/Type O Negative/Life Is Killing Me/Nettie
@@ -61,5 +61,5 @@ ____________
 Name  Nettie
 Artist  Type O Negative
 Album  Life Is Killing Me
-Written by  Peter Thomas Steele
+Original text by  Peter Thomas Steele
 Copyright  Universal Music Publishing Group

--- a/database/T/Type O Negative/October Rust/Love You To Death
+++ b/database/T/Type O Negative/October Rust/Love You To Death
@@ -38,5 +38,5 @@ ________________________________
 Name  My Girlfriend's Girlfriend
 Artist  Type O Negative
 Album  October Rust
-Written by  Peter Thomas Steele
+Original text by  Peter Thomas Steele
 Copyright  Universal Music Publishing Group

--- a/database/T/Type O Negative/October Rust/My Girlfriend's Girlfriend
+++ b/database/T/Type O Negative/October Rust/My Girlfriend's Girlfriend
@@ -54,5 +54,5 @@ ________________________________
 Name  My Girlfriend's Girlfriend
 Artist  Type O Negative
 Album  Bloody Kisses
-Written by  Peter Thomas Steele
+Original text by  Peter Thomas Steele
 Copyright  Universal Music Publishing Group


### PR DESCRIPTION
If the text was transcribed or is even slightest bit modified, it can't be claimed to be someone else's work in its entirety, hence `Original text by` seems like a more suitable statement here, as it keeps reference to the original author yet doesn't claim that the text in the current form is a work of theirs.
