### PR TITLE
Get rid of "Parody of" metadata keys

### DIFF
--- a/database/T/The Merkins/Man in the Box/Man in the Box
+++ b/database/T/The Merkins/Man in the Box/Man in the Box
@@ -58,4 +58,3 @@ _________________________
 Name       Man in the Box
 Artist     The Merkins
 Year       2020
-Parody of  Man in the Box by Alice In Chains

--- a/tests/database-tests.d/4-metadata.py
+++ b/tests/database-tests.d/4-metadata.py
@@ -19,7 +19,6 @@ def testForUnknownMetadataKeys(path, bytes, contents, text, metadata):
     "Language",
     "MusicBrainz ID",
     "Cover of",
-    "Parody of",
     "Samples",
     "Original text by",
     "Original text copyright",


### PR DESCRIPTION
Open Lyrics Database, unlike MusicBrainz, is a database of lyrics, and not metadata... integration with MusicBrainz via `MusicBrainz ID` should let us link recordings and artists/albums to data in MusicBrainz (e.g. for obtaining "Cover of" and "Parody of" values when building a website). Hence I'd like to propose to slowly get rid of metadata keys that are easily obtainable from MusicBrainz once `MusicBrainz ID` of the record is known.

The downside may be that recordings absent from MusicBrainz would not have that basic information available. Another issue is that both "Parody of" and "Cover of" won't be visible when the lyrics are viewed outside the website.
